### PR TITLE
ignore ressource in ignore_list

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,9 +176,6 @@ export const RULES_LIST = {
  */
 export function configPkg(...configBlocksToMerge) {
   return tseslint.config(
-    {
-      ignores: IGNORE_LIST,
-    },
     tseslint.configs.base,
     {
       name: 'Plugins list',
@@ -187,6 +184,7 @@ export function configPkg(...configBlocksToMerge) {
     {
       name: 'AdonisJS pkg defaults',
       files: INCLUDE_LIST,
+      ignores: IGNORE_LIST,
       rules: RULES_LIST,
     },
     ...configBlocksToMerge

--- a/index.js
+++ b/index.js
@@ -27,21 +27,21 @@ export const IGNORE_LIST = [
   '*.min.*',
   '*.d.ts',
   'CHANGELOG.md',
-  'dist',
+  'dist/**',
   'LICENSE*',
-  'output',
-  'coverage',
-  'temp',
-  'build',
-  'dist',
-  'public/assets',
+  'output/**',
+  'coverage/**',
+  'temp/**',
+  'build/**',
+  'dist/**',
+  'public/assets/**',
   'pnpm-lock.yaml',
   'yarn.lock',
   'package-lock.json',
-  '__snapshots__',
+  '__snapshots__/**',
+  'resources/**',
   '!.github',
   '!.vscode',
-  'resources/**'
 ]
 
 /**
@@ -214,9 +214,6 @@ export function configPkg(...configBlocksToMerge) {
  */
 export function configApp(...configBlocksToMerge) {
   return tseslint.config(
-    {
-      ignores: IGNORE_LIST,
-    },
     tseslint.configs.base,
     {
       name: 'Plugins list',
@@ -228,6 +225,7 @@ export function configApp(...configBlocksToMerge) {
     {
       name: 'AdonisJS app defaults',
       files: INCLUDE_LIST,
+      ignores: IGNORE_LIST,
       rules: {
         ...RULES_LIST,
         '@adonisjs/prefer-lazy-controller-import': ['error'],

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 /**
  * Default list of files to include
  */
-export const INCLUDE_LIST = ['**!(resources)/*.ts']
+export const INCLUDE_LIST = ['**/*.ts']
 
 /**
  * Default set of files to ignore
@@ -41,6 +41,7 @@ export const IGNORE_LIST = [
   '__snapshots__',
   '!.github',
   '!.vscode',
+  'resources/**'
 ]
 
 /**


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)


### 📚 Description

## Problem
The current ESLint configuration attempts to exclude the 'resources' directory using the `INCLUDE_LIST`, but this approach has unintended consequences. It not only excludes the 'resources' directory but also fails to lint files in sub-directories. For example:

- `app/middleware/UserController.ts` is not linted (no errors reported)
- `app/UserController.ts` is linted (shows "file-case" error)
- `resources/UserController.ts` is linted, which i think is inconsistent with the intended behavior of the previous commit 3753a66

This inconsistent behavior is demonstrated in the following screenshot:

![Capture d'écran 2024-09-11 154512](https://github.com/user-attachments/assets/6381bc37-6a29-4262-ac75-cdff7b958421)

## Solution

1. Updated `INCLUDE_LIST` to include all TypeScript files using a simpler pattern.
2. Rely on the `IGNORE_LIST` to exclude specific directories or files as needed.

With the new configuration `['**/*.ts'`], linting works correctly for all files:

![Capture d'écran 2024-09-11 144932](https://github.com/user-attachments/assets/bb1085cd-5a51-42c8-8c4a-18b0afa03048)

Hope this help 🚀

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
