### PR TITLE
feat: add jsdoc type for config blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,6 +173,8 @@ export const RULES_LIST = {
  *   }
  * })
  * ```
+ *
+ * @param {import('typescript-eslint').ConfigWithExtends[]} configBlocksToMerge
  */
 export function configPkg(...configBlocksToMerge) {
   return tseslint.config(
@@ -209,6 +211,8 @@ export function configPkg(...configBlocksToMerge) {
  *   }
  * })
  * ```
+ *
+ * @param {import('typescript-eslint').ConfigWithExtends[]} configBlocksToMerge
  */
 export function configApp(...configBlocksToMerge) {
   return tseslint.config(


### PR DESCRIPTION
### 🔗 Linked issue

Fixes https://github.com/adonisjs/eslint-config/issues/2

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add JSDoc type information for the `configBlocksToMerge` parameter of both `configPkg` and `configApp`. Doing this greatly improves the autocomplete experience for users who wish to override any part of the base config.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
