### PR TITLE
Add .yalc directory to global ignore list

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ export const GLOBAL_IGNORE_LIST = [
   'coverage/**',
   'temp/**',
   'build/**',
+  '.yalc/**',
   'pnpm-lock.yaml',
   'yarn.lock',
   'package-lock.json',


### PR DESCRIPTION
When extending Adonis, it's very common to need to use [`yalc`](https://npm.im/yalc) to link in packages under development.

Currently these packages would be included for linting and prettier, when they shouldn't be as they're "third-party" packages.

I think this change is correct? I only happened to notice it when using yalc to test out a new version of a package, opening it's types up and being greeted with a file full of red squiggles due to formatting issues.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
