### PR TITLE
feat: add React and Vue presets and include {vue,svelte} files in the inertia block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.idea/
+.vscode/
 node_modules
 package-lock.json

--- a/frameworks/react.js
+++ b/frameworks/react.js
@@ -1,0 +1,32 @@
+import tseslint from 'typescript-eslint'
+import reactPlugin from 'eslint-plugin-react'
+import reactHooksPlugin from 'eslint-plugin-react-hooks'
+import { RULES_LIST } from '../index.js'
+
+const INCLUDED_FILES = ['resources/js/**/*.{ts,tsx}', 'inertia/**/*.{ts,tsx}']
+
+/**
+ * React-specific ESLint config block. Make sure you have added [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks) to your ``devDependencies``
+ */
+const react = [
+  reactPlugin.configs.flat.recommended,
+  reactHooksPlugin.configs.flat.recommended,
+  {
+    name: 'AdonisJS React app overrides',
+    settings: {
+      react: { version: '19.0' },
+    },
+    rules: {
+      ...RULES_LIST,
+      'react/react-in-jsx-scope': 'off',
+      'react/prop-types': 'off',
+      'react/self-closing-comp': 'error',
+      'react/no-children-prop': 'off',
+      'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+].map((config) => ({ ...config, files: INCLUDED_FILES }))
+
+export { react }

--- a/frameworks/vue.js
+++ b/frameworks/vue.js
@@ -1,0 +1,30 @@
+import tseslint from 'typescript-eslint'
+import vuePlugin from 'eslint-plugin-vue'
+import { RULES_LIST } from '../index.js'
+
+/**
+ * Vue-specific ESLint config block. Make sure you have added [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue) to your ``devDependencies``
+ */
+const vue = [
+  ...vuePlugin.configs['flat/recommended'],
+  {
+    name: 'AdonisJS Vue app overrides',
+    files: ['resources/js/**/*.{ts,vue}', 'inertia/**/*.{ts,vue}'],
+    languageOptions: {
+      parserOptions: {
+        parser: tseslint.parser,
+      },
+    },
+    rules: {
+      ...RULES_LIST,
+      'vue/component-api-style': ['error', ['script-setup', 'composition']],
+      'vue/component-name-in-template-casing': ['error', 'PascalCase'],
+      'vue/define-emits-declaration': ['error', 'type-based'],
+      'vue/define-props-declaration': ['error', 'type-based'],
+      'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
+      'vue/multi-word-component-names': 'off',
+    },
+  },
+]
+
+export { vue }

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ export function configPkg(...configBlocksToMerge) {
  */
 const inertiaConfigBlock = {
   name: 'AdonisJS inertia app overrides',
-  files: ['inertia/**/*.{ts,tsx}'],
+  files: ['inertia/**/*.{ts,tsx,vue,svelte}'],
   rules: {
     '@adonisjs/no-backend-import-in-frontend': ['error'],
     '@adonisjs/prefer-adonisjs-inertia-link': ['error'],

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ import stylistic from '@stylistic/eslint-plugin'
 import adonisJSPlugin from '@adonisjs/eslint-plugin'
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 import vuePlugin from 'eslint-plugin-vue'
-import vueParser from 'vue-eslint-parser'
 
 /**
  * Default list of files to include
@@ -200,7 +199,6 @@ const vueConfigBlock = [
     name: 'AdonisJS Vue app overrides',
     files: ['inertia/**/*.vue'],
     languageOptions: {
-      parser: vueParser,
       parserOptions: {
         parser: tseslint.parser,
       },

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ import unicorn from 'eslint-plugin-unicorn'
 import stylistic from '@stylistic/eslint-plugin'
 import adonisJSPlugin from '@adonisjs/eslint-plugin'
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
-import vuePlugin from 'eslint-plugin-vue'
 
 /**
  * Default list of files to include
@@ -191,35 +190,11 @@ const inertiaConfigBlock = {
 }
 
 /**
- * Vue-specific ESLint config block
+ * Check if @adonisjs/inertia is installed
  */
-const vueConfigBlock = [
-  ...vuePlugin.configs['flat/recommended'],
-  {
-    name: 'AdonisJS Vue app overrides',
-    files: ['inertia/**/*.vue'],
-    languageOptions: {
-      parserOptions: {
-        parser: tseslint.parser,
-      },
-    },
-    rules: {
-      'vue/component-api-style': ['error', ['script-setup', 'composition']],
-      'vue/component-name-in-template-casing': ['error', 'PascalCase'],
-      'vue/define-emits-declaration': ['error', 'type-based'],
-      'vue/define-props-declaration': ['error', 'type-based'],
-      'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
-      'vue/multi-word-component-names': 'off',
-    },
-  },
-]
-
-/**
- * Check if a package is installed
- */
-function isPackageInstalled(pkg) {
+function isInertiaInstalled() {
   try {
-    import.meta.resolve(pkg)
+    import.meta.resolve('@adonisjs/inertia')
     return true
   } catch {
     return false
@@ -246,8 +221,7 @@ function isPackageInstalled(pkg) {
  * ```
  */
 export function configApp(...configBlocksToMerge) {
-  const inertia = isPackageInstalled('@adonisjs/inertia')
-  const vue = isPackageInstalled('vue')
+  const inertia = isInertiaInstalled()
 
   return tseslint.config(
     { ignores: GLOBAL_IGNORE_LIST },
@@ -272,7 +246,6 @@ export function configApp(...configBlocksToMerge) {
       },
     },
     ...(inertia ? [inertiaConfigBlock] : []),
-    ...(vue ? vueConfigBlock : []),
     ...configBlocksToMerge
   )
 }

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ import unicorn from 'eslint-plugin-unicorn'
 import stylistic from '@stylistic/eslint-plugin'
 import adonisJSPlugin from '@adonisjs/eslint-plugin'
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
+import vuePlugin from 'eslint-plugin-vue'
+import vueParser from 'vue-eslint-parser'
 
 /**
  * Default list of files to include
@@ -190,11 +192,36 @@ const inertiaConfigBlock = {
 }
 
 /**
- * Check if @adonisjs/inertia is installed
+ * Vue-specific ESLint config block
  */
-function isInertiaInstalled() {
+const vueConfigBlock = [
+  ...vuePlugin.configs['flat/recommended'],
+  {
+    name: 'AdonisJS Vue app overrides',
+    files: ['inertia/**/*.vue'],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: {
+        parser: tseslint.parser,
+      },
+    },
+    rules: {
+      'vue/component-api-style': ['error', ['script-setup', 'composition']],
+      'vue/component-name-in-template-casing': ['error', 'PascalCase'],
+      'vue/define-emits-declaration': ['error', 'type-based'],
+      'vue/define-props-declaration': ['error', 'type-based'],
+      'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
+      'vue/multi-word-component-names': 'off',
+    },
+  },
+]
+
+/**
+ * Check if a package is installed
+ */
+function isPackageInstalled(pkg) {
   try {
-    import.meta.resolve('@adonisjs/inertia')
+    import.meta.resolve(pkg)
     return true
   } catch {
     return false
@@ -221,7 +248,8 @@ function isInertiaInstalled() {
  * ```
  */
 export function configApp(...configBlocksToMerge) {
-  const inertia = isInertiaInstalled()
+  const inertia = isPackageInstalled('@adonisjs/inertia')
+  const vue = isPackageInstalled('vue')
 
   return tseslint.config(
     { ignores: GLOBAL_IGNORE_LIST },
@@ -246,6 +274,7 @@ export function configApp(...configBlocksToMerge) {
       },
     },
     ...(inertia ? [inertiaConfigBlock] : []),
+    ...(vue ? vueConfigBlock : []),
     ...configBlocksToMerge
   )
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-unicorn": "^63.0.0",
-    "typescript-eslint": "^8.58.0"
+    "eslint-plugin-vue": "^10.9.1",
+    "typescript-eslint": "^8.58.0",
+    "vue-eslint-parser": "^10.4.0"
   },
   "homepage": "https://github.com/adonisjs/eslint-config#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-unicorn": "^63.0.0",
     "eslint-plugin-vue": "^10.9.1",
-    "typescript-eslint": "^8.58.0",
-    "vue-eslint-parser": "^10.4.0"
+    "typescript-eslint": "^8.58.0"
   },
   "homepage": "https://github.com/adonisjs/eslint-config#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "main": "index.js",
   "type": "module",
   "files": [
-    "index.js"
+    "index.js",
+    "frameworks"
   ],
+  "exports": {
+    ".": "./index.js",
+    "./vue": "./frameworks/vue.js",
+    "./react": "./frameworks/react.js"
+  },
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write .",
@@ -21,7 +27,21 @@
   },
   "peerDependencies": {
     "eslint": "^9.9.0 || ^10.0.0",
-    "prettier": "^3.8.1"
+    "prettier": "^3.8.1",
+    "eslint-plugin-vue": "^10.9.1",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.1.1"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-vue": {
+      "optional": true
+    },
+    "eslint-plugin-react": {
+      "optional": true
+    },
+    "eslint-plugin-react-hooks": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@adonisjs/eslint-plugin": "^2.2.2",
@@ -29,7 +49,6 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-unicorn": "^63.0.0",
-    "eslint-plugin-vue": "^10.9.1",
     "typescript-eslint": "^8.58.0"
   },
   "homepage": "https://github.com/adonisjs/eslint-config#readme",


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

## 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://discord.com/channels/423256550564691970/1508079210114056354

## ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The purpose of this PR is to fix an issue with the Vue ecosystem. It looks like eslint needs eslint-plugin-vue to work properly with vue files.

### So this PR makes the following changes:
1. Adding ``.vue`` to the ``inertiaConfigBlocks.files`` glob. 
   - I also added svelte just in case, but if you'd rather I remove it, I can.
2. Added Vue-specific settings to make it work with ESLint

### We can implement the second one in two ways (here, I suggested the first one)
* Adding a vue block config, as with Inertia
   * This option helps keep the configApp() clean in starter kits
   * But, of course, users who don't use Vue will end up with a dependence when they add @adonisjs/eslint-config. 
* Or, adding the specific vue config into the inertia-vue starter-kits

Feel free to let me know if my suggestion works for you or if you'd prefer the second solution.

### About the suggested solution
* Added a dependence: ``eslint-plugin-vue``
* I added a few basic rules for Vue, but disabled ``vue/multi-word-component-names``. To be transparent: I asked the AI, since I’m not very good with ESLint rules, and filtered out the ones that seemed less relevant to me.
```js
rules: {
      'vue/component-api-style': ['error', ['script-setup', 'composition']],
      'vue/component-name-in-template-casing': ['error', 'PascalCase'],
      'vue/define-emits-declaration': ['error', 'type-based'],
      'vue/define-props-declaration': ['error', 'type-based'],
      'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
      'vue/multi-word-component-names': 'off',
},
```

### Chore things
I added ``.vscode/`` and ``.idea/`` to ``.gitignore``.

-------

I hope this helps.

Thank you for the work you do every day.

*(Sorry if my English is not perfect or verbose)*

## 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
